### PR TITLE
Fix GetX error in assistant view

### DIFF
--- a/lib/app/modules/assistant/views/assistant_view.dart
+++ b/lib/app/modules/assistant/views/assistant_view.dart
@@ -36,7 +36,7 @@ class AssistantView extends GetView<AssistantController> {
                       style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                     ),
                     const SizedBox(height: 8),
-                    Obx(() => Text(controller.connectionStatus)),
+                    Text(controller.connectionStatus),
                   ],
                 ),
               ),


### PR DESCRIPTION
- Remove unnecessary Obx wrapper from connectionStatus text
- connectionStatus is a computed getter, not an observable variable
- Resolves 'improper use of GetX' error in Visual Studio Code
- Verified fix by testing Flutter app runs without GetX errors